### PR TITLE
duplicate git declaration

### DIFF
--- a/manifests/puppet/foss_master.pp
+++ b/manifests/puppet/foss_master.pp
@@ -34,7 +34,9 @@ class psick::puppet::foss_master (
     $postgresversion = '9.6'
   }
 
-  contain ::psick::git
+  if !defined(Class['git']) {
+    contain ::psick::git
+  }
   contain puppetserver
   # Workflow: create puppetserver ssl ca and certificates
   ini_setting { 'puppet master dns alt names':
@@ -59,7 +61,6 @@ class psick::puppet::foss_master (
     class { 'r10k':
       remote   => $r10k_remote_repo,
       provider => 'puppet_gem',
-      require  => Class['psick::git'],
     }
     class {'r10k::webhook::config':
       enable_ssl      => false,


### PR DESCRIPTION
use psick::git class only when not using r10k as r10k enforces git
installation by using puppetlabs-git.
there is no parameter on r10k module to overwrite this behavior