### PR TITLE
Update install_puppet task to run in bolt

### DIFF
--- a/tasks/install_puppet
+++ b/tasks/install_puppet
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-breed=$1
+breed=$PT_breed
 if [[ $EUID -ne 0 ]]; then
   pre_command='sudo '
 else

--- a/tasks/install_puppet.json
+++ b/tasks/install_puppet.json
@@ -1,5 +1,11 @@
 {
   "description": "Install Puppet agent on a node",
   "supports_noop": false,
-  "input_method": "stdin"
+  "input_method": "environment",
+  "parameters": {
+    "breed": {
+      "description": "What 'breed', or flavour of operatingsystem we're installing (defaults to linux)",
+      "type": "Optional[Enum['solaris','darwin','linux','bsd','cygwin','msys','win']]"
+    }
+  }   
 }


### PR DESCRIPTION
The previous metadata had the 'stdin' input method, which expects json on stdin.
I adjusted the metadata to use the 'environment' input method, which takes
environment variables named $PT_foo for parameter foo, and also adjusted
the script to match. 