### PR TITLE
use correct puppet agent parameter for server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 
 * Your contribution here.
+* Use correct puppet agent parameter for server - [@tuxmea](https://github.com/tuxmea).
 
 ## Release 0.5.6
 

--- a/tasks/puppet_agent.sh
+++ b/tasks/puppet_agent.sh
@@ -8,7 +8,7 @@ fi
 
 declare puppet_options
 puppet_options="--detailed-exitcodes"
-[[ -n "${PT_puppet_master}" ]] && puppet_options="${puppet_options} --master ${PT_puppet_master}"
+[[ -n "${PT_puppet_master}" ]] && puppet_options="${puppet_options} --server ${PT_puppet_master}"
 [[ -n "${PT_verbose}" ]] && puppet_options="${puppet_options} --verbose"
 [[ -n "${PT_debug}" ]] && puppet_options="${puppet_options} --debug"
 [[ -n "${PT_noop}" ]] && puppet_options="${puppet_options} --noop"


### PR DESCRIPTION
psick::puppet_agent task uses wrong parameter for server (uses master instead of server)