### PR TITLE
Start puppetserver before puppetdb configuration.

### DIFF
--- a/manifests/puppet/foss_master.pp
+++ b/manifests/puppet/foss_master.pp
@@ -125,7 +125,7 @@ class psick::puppet::foss_master (
       manage_report_processor => true,
       enable_reports          => true,
       restart_puppet          => false,
-      before                  => Service['puppetserver'],
+      require                 => Service['puppetserver'],
     }
     if $enable_puppetdb_sslsetup {
       exec { 'puppetdb ssl-setup':


### PR DESCRIPTION
To configure puppetdb puppetserver have to be up and running.
This commit set 'require' for puppetserver service
for puppetdb::master::config.